### PR TITLE
Made the plugin to work in parrallel threads

### DIFF
--- a/addon/services/template-inspector.js
+++ b/addon/services/template-inspector.js
@@ -5,22 +5,10 @@ export default class TemplateInspectorService extends Service {
     super(...arguments);
     let { serverUrl } = window.emberTemplateInspector || {};
     this.serverUrl = serverUrl;
-
-    this.fetchFileInfo();
-  }
-
-  async fetchFileInfo() {
-    let { serverUrl = '' } = this;
-    let { file_location_hash } = await fetch(`${serverUrl}/fileinfo`).then(
-      (res) => res.json()
-    );
-    this.fileLocationHash = file_location_hash;
   }
 
   getFileInfo(fileInfo) {
-    let [appOrAddon, fileIndex, line, column] = fileInfo.split(':');
-    let fileName = this.fileLocationHash[appOrAddon].files[fileIndex];
-
+    let [_, fileName, line, column] = fileInfo.split(':');
     return `${fileName}:${line}:${column}`;
   }
 

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -1,0 +1,19 @@
+const FileNamePlugin = require('./file-name-plugin');
+
+module.exports = {
+  buildPlugin(params) {
+    let { moduleName, appOrAddonIndex, pluginDir } = params;
+    return {
+      name: 'file-name-plugin',
+      plugin: FileNamePlugin({ moduleName, appOrAddonIndex }),
+      parallelBabel: {
+        requireFile: __filename,
+        buildUsing: 'buildPlugin',
+        params
+      },
+      baseDir() {
+        return pluginDir;
+      }
+    };
+  },
+};

--- a/lib/file-name-plugin.js
+++ b/lib/file-name-plugin.js
@@ -5,13 +5,12 @@ const locationAttribute = 'l';
 const blockHelpers = ['each', 'each-in', 'let', 'with', 'if', 'unless'];
 const undasherizedComponents = ['input', 'component'];
 
-module.exports = function ({ appOrAddonIndex, fileIndex, files }) {
+module.exports = function ({ appOrAddonIndex, moduleName }) {
   return class Plugin {
     constructor(env) {
       if (env.moduleName) {
-        files[fileIndex] = env.moduleName;
-        this.fileHash = `${appOrAddonIndex}:${fileIndex}`;
-        fileIndex++;
+        let fileName = env.moduleName.replace(`${moduleName}/`, '');
+        this.fileHash = `${appOrAddonIndex}:${fileName}`;
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-template-inspector",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "An ember add-on which opens the template file in the code editor while inspecting an element.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Now the plugin can do transforms in parallel threads without blocking other processes in the main thread.
But the node_modules/**/*.hbs and in-repo-addon/**/*.hbs files are can't be indexed in files hash, so that we have to include the filename for all files in the 'l'(location) attribute.